### PR TITLE
fix: display breakpoints for debugging

### DIFF
--- a/_layouts/base.html.twig
+++ b/_layouts/base.html.twig
@@ -93,21 +93,22 @@
 
         <a href="#main-content" class="sr-only sr-only-focusable c-skip-content">Skip to Content</a>
 
-        {% if site.debug %}
-            <section class="c-screensize">
-                <div class="c-screensize--xl">xl</div>
-                <div class="c-screensize--lg">lg</div>
-                <div class="c-screensize--md">md</div>
-                <div class="c-screensize--sm">sm</div>
-                <div class="c-screensize--xs">xs</div>
-            </section>
-        {% endif %}
-
         {# ----------------- Actual Page Content ----------------- #}
 
         <div class="c-body">
             {% block body %}{% endblock %}
         </div>
+
+        {% if site.debug %}
+            <div class="-debug-viewport" aria-hidden="true">
+                <span class="hide-sm">xs</span>
+                <span class="hide-xs show-sm hide-md">sm</span>
+                <span class="hide-xs show-md hide-lg">md</span>
+                <span class="hide-xs show-lg hide-xl">lg</span>
+                <span class="hide-xs show-xl hide-2xl">xl</span>
+                <span class="hide-xs show-2xl">2xl</span>
+            </div>
+        {% endif %}
 
         {# ------------ Everything Javascript Related ------------ #}
 

--- a/_layouts/page.html.twig
+++ b/_layouts/page.html.twig
@@ -1,7 +1,43 @@
 {% extends '_layouts/base.html.twig' %}
 
 {% block body %}
-    <aside class="c-sidebar u-background-dark">
+    <div class="c-page-header">
+        <button
+            class="c-header-button c-hamburger"
+            aria-expanded="false"
+            aria-controls="sidebar-lhs"
+            data-role="class-toggler"
+            data-target=".c-body"
+            data-toggle-class="u-nav-open"
+        >
+            <span></span>
+
+            <span class="sr-only">toggle menu</span>
+        </button>
+
+        <a class="c-page-header-title" href="{{ url('/') }}">allejo</a>
+
+        {% if this.has_toc %}
+            <button
+                class="c-header-button c-toc-toggle"
+                aria-expanded="false"
+                aria-controls="sidebar-rhs"
+                data-role="class-toggler"
+                data-target=".c-body"
+                data-toggle-class="u-toc-open"
+            >
+                <span class="c-toc-toggle__line"></span>
+                <span class="c-toc-toggle__line"></span>
+                <span class="c-toc-toggle__line"></span>
+
+                <span class="sr-only">toggle table of contents</span>
+            </button>
+        {% else %}
+            <div class="c-header-placeholder"></div>
+        {% endif %}
+    </div>
+
+    <aside id="sidebar-lhs" class="c-sidebar-lhs u-background-dark">
         <div class="c-branding mb-5">
             <a href="{{ url(pages['Home']) }}" class="c-branding__logo">allejo</a>
         </div>
@@ -17,32 +53,35 @@
         <p>Copyright &copy; {{ 'now' | date('Y') }}</p>
     </aside>
 
-    <main class="c-page u-background-light">
-        <span id="main-content"></span>
+    <div class="c-page">
+        <main class="c-content u-background-light">
+            <div class="c-print-header">
+                <p class="c-print-header__title">allejo</p>
+                <p class="c-print-header__slogan">
+                    {{ site.motto }} &bull; <a href="{{ site.url }}">{{ site.url }}</a>
+                </p>
+            </div>
 
-        <div class="c-page-header">
-            <button class="c-hamburger c-hamburger--htx">
-                <span></span>
+            <span id="main-content"></span>
+            {% block content %}{% endblock %}
 
-                <span class="sr-only">toggle menu</span>
-            </button>
-        </div>
+            <footer class="c-site-footer">
+                <ul class="u-list-inline">
+                    <li><a href="{{ url(pages['Support Me']) }}">Support Me</a></li>
+                    <li><a href="{{ url(pages['Supporters']) }}">Sponsors</a></li>
+                    <li><a href="{{ url(pages['Contact']) }}">Contact</a></li>
+                </ul>
+            </footer>
+        </main>
 
-        <div class="c-print-header">
-            <p class="c-print-header__title">allejo</p>
-            <p class="c-print-header__slogan">
-                {{ site.motto }} &bull; <a href="{{ site.url }}">{{ site.url }}</a>
-            </p>
-        </div>
+        {% if this.has_toc %}
+            <div id="sidebar-rhs" class="c-sidebar-rhs">
+                <aside class="c-table-of-contents u-background-white">
+                    <h2 class="h5 mt-0 mb-2">On This Page</h2>
 
-        {% block content %}{% endblock %}
-
-        <footer class="c-site-footer">
-            <ul class="u-list-inline">
-                <li><a href="{{ url(pages['Support Me']) }}">Support Me</a></li>
-                <li><a href="{{ url(pages['Supporters']) }}">Sponsors</a></li>
-                <li><a href="{{ url(pages['Contact']) }}">Contact</a></li>
-            </ul>
-        </footer>
-    </main>
+                    {{ block('content') | toc(hMin=2, class="m-0 pl-4") }}
+                </aside>
+            </div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/_sass/abstracts/_variables.scss
+++ b/_sass/abstracts/_variables.scss
@@ -74,7 +74,8 @@ $breakpoints: (
   sm: 576px,
   md: 768px,
   lg: 992px,
-  xl: 1200px
+  xl: 1200px,
+  2xl: 1580px,
 );
 
 $width-sidebar: 18em;

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -30,3 +30,7 @@ body {
       background-color: transparent;
   }
 }
+
+.c-body {
+  position: relative;
+}

--- a/_sass/components/_hamburger.scss
+++ b/_sass/components/_hamburger.scss
@@ -3,10 +3,9 @@
 //
 
 .c-hamburger {
-    display: block;
+    display: flex;
     position: relative;
     overflow: hidden;
-    left: -5px;
     margin: 0;
     padding: 0;
     width: $hamburger-width;
@@ -25,6 +24,7 @@
     right: $hamburger-padding;
     height: $hamburger-bar-thickness;
     background: white;
+  transition: background 0s $hamburger-transistion-duration;
 }
 
 .c-hamburger span::before,
@@ -36,63 +36,112 @@
     height: $hamburger-bar-thickness;
     background-color: #fff;
     content: "";
+  transition-duration: $hamburger-transistion-duration, $hamburger-transistion-duration;
+  transition-delay: $hamburger-transistion-duration, 0s;
 }
 
 .c-hamburger span::before {
     top: -$hamburger-bar-thickness - $hamburger-bar-padding;
+  transition-property: top, transform;
 }
 
 .c-hamburger span::after {
     bottom: -$hamburger-bar-thickness - $hamburger-bar-padding;
-}
-
-// Hamburger to "x"
-
-.c-hamburger--htx {
-    background-color: $hamburger-color;
-}
-
-.c-hamburger--htx span {
-    transition: background 0s $hamburger-transistion-duration;
-}
-
-.c-hamburger--htx span::before,
-.c-hamburger--htx span::after {
-    transition-duration: $hamburger-transistion-duration, $hamburger-transistion-duration;
-    transition-delay: $hamburger-transistion-duration, 0s;
-}
-
-.c-hamburger--htx span::before {
-    transition-property: top, transform;
-}
-
-.c-hamburger--htx span::after {
-    transition-property: bottom, transform;
+  transition-property: bottom, transform;
 }
 
 /* active state, i.e. menu open */
 
 .u-nav-open {
-    .c-hamburger--htx {
-        background-color: $hamburger-color-active;
-
+    .c-hamburger {
         span {
             background: none;
         }
     }
 
-    .c-hamburger--htx span::before {
+    .c-hamburger span::before {
         top: 0;
         transform: rotate(45deg);
     }
 
-    .c-hamburger--htx span::after {
+    .c-hamburger span::after {
         bottom: 0;
         transform: rotate(-45deg);
     }
 
-    .c-hamburger--htx span::before,
-    .c-hamburger--htx span::after {
+    .c-hamburger span::before,
+    .c-hamburger span::after {
         transition-delay: 0s, $hamburger-transistion-duration;
     }
+}
+
+.c-toc-toggle {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: $hamburger-bar-padding;
+    padding: 10px;
+}
+
+.c-toc-toggle__line {
+    background-color: white;
+    display: block;
+    height: $hamburger-bar-thickness;
+    margin-left: 5px;
+    position: relative;
+
+    --line-width: calc(100% - 5px);
+
+    &::before {
+        content: "";
+        position: absolute;
+        left: -5px;
+        height: $hamburger-bar-thickness;
+        width: $hamburger-bar-thickness;
+        background-color: white;
+    }
+
+    &:nth-child(1) {
+        width: var(--line-width);
+    }
+
+    &:nth-child(2) {
+        width: calc(var(--line-width) * 2/3);
+    }
+
+    &:nth-child(3) {
+        width: calc(var(--line-width) * 1/3);
+    }
+}
+
+.c-header-button,
+.c-header-placeholder {
+  height: $hamburger-height;
+  width: $hamburger-width;
+}
+
+.c-header-button {
+  appearance: none;
+  background-color: $hamburger-color;
+  border: 0;
+  border-radius: 0;
+  cursor: pointer;
+  display: flex;
+  transition: background $hamburger-transistion-duration, left $hamburger-transistion-duration;
+}
+
+.u-toc-open .c-toc-toggle,
+.u-nav-open .c-toc-toggle,
+.u-nav-open .c-hamburger {
+  background-color: $hamburger-color-active;
+}
+
+.u-toc-open.u-nav-open {
+  .c-toc-toggle {
+    background-color: var(--stx-color-white);
+  }
+
+  .c-toc-toggle__line,
+  .c-toc-toggle__line::before {
+    background-color: var(--stx-color-blue-dark);
+  }
 }

--- a/_sass/components/_table-of-contents.scss
+++ b/_sass/components/_table-of-contents.scss
@@ -1,0 +1,9 @@
+.c-table-of-contents {
+  @include padding(null, 4);
+
+  border-left: 5px solid var(--stx-color-blue-dark);
+  min-width: 250px;
+  left: 0;
+  position: sticky;
+  top: map-get($spacing, 4);
+}

--- a/_sass/layout/_header.scss
+++ b/_sass/layout/_header.scss
@@ -1,23 +1,18 @@
 .c-page-header {
     $_spacing: map-get($spacing, 3);
 
+    align-items: center;
     background-color: $hamburger-color;
+    display: flex;
+    justify-content: space-between;
     height: $hamburger-height;
-    margin: 0 (-1 * $_spacing) $_spacing;
     padding: 0 $_spacing;
-    position: relative;
-    transition: background-color $hamburger-transistion-duration;
-
-    @include respond-up(sm) {
-        margin: {
-            left: (-2 * $_spacing);
-            right: (-2 * $_spacing);
-        }
-        padding: {
-            left: (2 * $_spacing);
-            right: (2 * $_spacing);
-        }
-    }
+    position: fixed;
+    right: 0;
+    top: 0;
+    transition: background-color $hamburger-transistion-duration, width $hamburger-transistion-duration, padding-left $hamburger-transistion-duration;
+    width: 100vw;
+    z-index: 20;
 
     @include respond-up(lg) {
         display: none;
@@ -51,14 +46,29 @@
     margin-top: -7px;
 }
 
+.c-page-header-title {
+  color: var(--stx-color-white);
+  font-family: $font-stack-branding;
+  font-size: 1.5rem;
+  font-weight: 300;
+  letter-spacing: 0.2rem;
+  line-height: 1;
+
+  &:focus,
+  &:hover {
+    color: var(--stx-color-egg-yolk);
+  }
+}
+
 .u-nav-open {
     .c-page-header {
         background-color: $hamburger-color-active;
+        min-width: 100px;
+        padding-left: 0;
+        width: calc(100vw - (#{$width-sidebar} - #{$hamburger-width}));
     }
-}
 
-.u-nav-open .c-hamburger {
-    left: calc(#{$width-sidebar} - #{$hamburger-width});
-    position: fixed;
-    z-index: 15;
+    .c-page-header-title {
+        display: none;
+    }
 }

--- a/_sass/layout/_page.scss
+++ b/_sass/layout/_page.scss
@@ -1,10 +1,19 @@
 .c-page {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  margin-top: $hamburger-height + 16px;
+
+  @include margin(t, 0, lg);
+}
+
+.c-content {
   @include padding(x, 3);
   @include padding(null, 5, lg);
 
   @include respond-up(lg) {
     margin-left: $width-sidebar;
-    max-width: 1000px;
+    max-width: 800px;
   }
 
   img {

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -1,4 +1,4 @@
-.c-sidebar {
+.c-sidebar-lhs {
   @include padding(y, 5);
 
   background-color: $color-background-dark;
@@ -6,6 +6,7 @@
   left: -1 * $width-sidebar;
   position: fixed;
   text-align: center;
+  top: 0;
   transition: left 0.3s;
   width: $width-sidebar;
   z-index: 10;
@@ -25,8 +26,29 @@
   }
 }
 
+.c-sidebar-rhs {
+  position: fixed;
+  right: 0;
+  top: $hamburger-height;
+  visibility: hidden;
+  z-index: 30;
+
+  @include respond-up(lg) {
+    @include margin(t, 5);
+
+    position: unset;
+    visibility: visible;
+  }
+}
+
 .u-nav-open {
-  .c-sidebar {
+  .c-sidebar-lhs {
     left: 0;
+  }
+}
+
+.u-toc-open {
+  .c-sidebar-rhs {
+    visibility: visible;
   }
 }

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -1,4 +1,5 @@
 .c-sidebar-lhs {
+  @include padding(x, 4);
   @include padding(y, 5);
 
   background-color: $color-background-dark;

--- a/_sass/styles.scss.twig
+++ b/_sass/styles.scss.twig
@@ -52,6 +52,7 @@ permalink: /assets/css/styles.css
 @import 'components/social';
 @import 'components/split-container';
 @import 'components/svg-icon';
+@import 'components/table-of-contents';
 @import 'components/tabs';
 @import 'components/tags';
 @import 'components/thumbnail';

--- a/_sass/styles.scss.twig
+++ b/_sass/styles.scss.twig
@@ -64,3 +64,14 @@ permalink: /assets/css/styles.css
 @import 'utilities/spacing';
 @import 'utilities/typography';
 @import 'utilities/visibility';
+
+.-debug-viewport {
+    @include padding(null, 2);
+
+    background-color: maroon;
+    bottom: 0;
+    color: white;
+    opacity: 50%;
+    position: fixed;
+    right: 0;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,34 +1,17 @@
 "use strict";
 
-/**
- * Toggle a class for an element.
- *
- * @param {Element} element
- * @param {string} toggleClass
- *
- * @link https://stackoverflow.com/a/25544148
- */
-function toggleClass(element, toggleClass){
-    var currentClass = element.className;
-    var newClass;
+const toggleButtons = document.querySelectorAll('[data-role="class-toggler"]');
 
-    if (currentClass.split(' ').indexOf(toggleClass) > -1) {
-        newClass = currentClass.replace(new RegExp('\\b' + toggleClass + '\\b', 'g'), '')
-    } else {
-        newClass = currentClass + ' ' + toggleClass;
-    }
-
-    element.className = newClass.trim();
-}
-
-var hamburger = document.getElementsByClassName('c-hamburger');
-
-if (hamburger.length) {
-    hamburger[0].addEventListener('click', function (ev) {
+for (const toggleButton of toggleButtons) {
+    toggleButton.addEventListener('click', function (ev) {
         ev.preventDefault();
 
-        var body = document.getElementsByClassName('c-body');
+        const targetSelector = this.getAttribute('data-target');
+        const toggleClass = this.getAttribute('data-toggle-class');
 
-        toggleClass(body[0], 'u-nav-open');
+        const targetElement = document.querySelector(targetSelector);
+
+        targetElement.classList.toggle(toggleClass);
+        this.setAttribute('aria-expanded', targetElement.classList.contains(toggleClass) ? 'true' : 'false');
     });
 }


### PR DESCRIPTION
Add some branding to my mobile page header.

<img width="855" height="299" alt="image" src="https://github.com/user-attachments/assets/07a55b33-1a42-4034-aae7-48d9ddd5edfa" />

Add a table of contents for pages when `has_toc` is set to true in the FrontMatter of a page.

<img width="856" height="235" alt="image" src="https://github.com/user-attachments/assets/0c5c47b4-9958-441d-bbce-0595afe4dbf4" />

Mobile branding is hidden when the left sidebar is open and the table of contents button is inverted when it's open and the sidebar is expanded.

<img width="855" height="215" alt="image" src="https://github.com/user-attachments/assets/d39a86fb-b716-4deb-bb0c-7681628c6007" />